### PR TITLE
automate patron roles

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,8 +33,8 @@ HELP_STRING = """
 :book: **Commands:**
 !assign [role]: *assign yourself to one of the available roles.*\n
 !unassign [role]: *unassign yourself from a role.*\n
-!roles: *list available roles.*"""
-
+!roles: *list available roles.*\n
+!patreon [#hex]: *select custom colour if a patron"""
 
 # How long to wait to delete messages
 FEEDBACK_DEL_TIMER = 5
@@ -536,7 +536,41 @@ async def on_message(message):
                     tmp, FEEDBACK_DEL_TIMER, error=True, call_msg=message
                 )
 
-
+    elif message.content.startswith("!patreon"):
+        is_donator = False
+        for r in message.author.roles: #check if donator
+            if r.name.lower() == "donor":
+                is_donator = True
+        if is_donator:
+            colour_hex = message.content[10:]
+            if not len(colour_hex) or not message.content[8:10] == " #":
+                tmp = await client.send_message(message.channel, "Usage: **!patreon #ff0000** is red\n**!patreon #00ff00** is green\netc...")
+                await delete_edit_timer(tmp, FEEDBACK_DEL_TIMER, call_msg=message)
+                return
+            else: #check if hexademical number
+                try:
+                    role_colour = int(colour_hex, 16)
+                except ValueError:
+                    tmp = await client.send_message(
+                    message.channel, "Not a hexademical number")
+                    await delete_edit_timer(tmp, FEEDBACK_DEL_TIMER, call_msg=message)
+                    return
+                if role_colour > 16777216 or role_colour < 0:
+                    tmp = await client.send_message(message.channel, "Usage: **!patreon #ff0000** is red\n**!patreon #00ff00** is green\netc...")
+                    await delete_edit_timer(tmp, FEEDBACK_DEL_TIMER, call_msg=message)
+                    return
+                role_name = "donor_c_" + str(message.author)
+                for r in message.author.roles: #check if user has a patreon role and delete it
+                    if r.name.startswith("donor_"):
+                        await client.delete_role(message.server, r)
+                new_role = await client.create_role(
+                    message.server, name=role_name, colour=discord.Colour(role_colour)
+                )
+                await client.add_roles(message.author, new_role)
+        else:
+            tmp = await client.send_message(
+                message.channel, "You have to be a patron to get a custom colour. If you are a patron and see this message, please contact a moderator.\n\nhttps://www.patreon.com/godotengine")
+                
 @client.event
 async def on_member_join(member):
     # Actions to take when a new member joins the server.

--- a/main.py
+++ b/main.py
@@ -22,6 +22,9 @@ AVAILABLE_ROLES = [
     "sound designer"
 ]
 
+# Color roles will be put under this
+PARENT_COLOR_ROLE = "colors"
+
 # Channel ID's
 NEWCOMER_CHANNEL = "253576562136449024"
 GENERAL_CHANNEL = "212250894228652034"
@@ -562,38 +565,38 @@ async def on_message(message):
                 role_name = "color_" + str(message.author)
                 author_roles = message.author.roles.copy()
                 for r in author_roles: #check if user has already a colour role and edit the colour
-                    if r.name.startswith("color"):
+                    if r.name.startswith("color_"):
                         await client.edit_role(message.server, r, colour=discord.Colour(role_colour))
                         return
                 server_roles = message.server.roles.copy()
-                for r in server_roles: #check position of donor role
-                    if r.name.lower() == "donor":
-                        donor_pos = r.position
+                for r in server_roles: #get position of the parent role
+                    if r.name.lower() == PARENT_COLOR_ROLE.lower():
+                        parent_pos = r.position
                 new_role = await client.create_role(
                     message.server, name=role_name, colour=discord.Colour(role_colour)
                 )
-                await client.move_role(message.server, new_role, donor_pos)
+                await client.move_role(message.server, new_role, parent_pos)
                 await client.add_roles(message.author, new_role)
         else:
             tmp = await client.send_message(
                 message.channel, "You have to be a patron to get a custom colour. If you are a patron and get this message, please contact a moderator.\n\nhttps://www.patreon.com/godotengine")
 
-    elif message.content.startswith("!sort"): # moving all the colour roles below Donor role
+    elif message.content.startswith("!sort"): # moving all the colour roles below parent role
         is_admin = False
         for admin in message.author.roles: #check if admin
             if admin.name.lower() == "admin":
                 is_admin = True
                 break
         if is_admin:
-            donor_pos = 0
+            parent_pos = 0
             server_role_list = message.server.roles.copy()
             for r in server_role_list:
-                if r.name.lower() == "donor":
-                    donor_pos = r.position
+                if r.name.lower() == PARENT_COLOR_ROLE.lower():
+                    parent_pos = r.position
                     break
             for r in server_role_list:
-                if r.name.lower().startswith("color"):
-                    await client.move_role(message.server, r, donor_pos - 1)
+                if r.name.lower().startswith("color_"):
+                    await client.move_role(message.server, r, parent_pos - 1)
 
     elif message.content.startswith("!purge"): # delete colour roles for members who are no longer patrons
         is_admin = False
@@ -606,7 +609,7 @@ async def on_message(message):
             for m in message.server.members: #check if a user has donor color role but not a donor role
                 if not "donor" in (r.name.lower() for r in m.roles):
                     for role in m.roles:
-                        if role.name.startswith("color"):
+                        if role.name.startswith("color_"):
                             kills += 1
                             await client.delete_role(message.server, role)
             await client.send_message(message.channel, "kill count:  " + str(kills))

--- a/main.py
+++ b/main.py
@@ -555,47 +555,61 @@ async def on_message(message):
                     message.channel, "Not a hexademical number")
                     await delete_edit_timer(tmp, FEEDBACK_DEL_TIMER, call_msg=message)
                     return
-                if role_colour > 16777216 or role_colour < 0:
+                if role_colour > 16777215 or role_colour < 0:
                     tmp = await client.send_message(message.channel, "Usage: `!patreon #ff0000` is red\n`!patreon #00ff00` is green\netc...")
                     await delete_edit_timer(tmp, FEEDBACK_DEL_TIMER, call_msg=message)
                     return
-                role_name = "donor_c_" + str(message.author)
-                for r in message.author.roles: #check if user has already a donor colour role and delete it
-                    if r.name.startswith("donor_"):
-                        await client.delete_role(message.server, r)
-                for r in message.server.roles: #check position of donor role
+                role_name = "color_" + str(message.author)
+                server_roles = message.server.roles.copy()
+                for r in server_roles: #check position of donor role
                     if r.name.lower() == "donor":
                         donor_pos = r.position
                 new_role = await client.create_role(
                     message.server, name=role_name, colour=discord.Colour(role_colour)
                 )
-                await client.move_role(message.server, new_role, donor_pos + 1)
+                await client.move_role(message.server, new_role, donor_pos)
+                author_roles = message.author.roles.copy()
+                for k in author_roles: #check if user has already a donor colour role and delete it
+                    if k.name.startswith("color"):
+                        await client.delete_role(message.server, k)
                 await client.add_roles(message.author, new_role)
         else:
             tmp = await client.send_message(
                 message.channel, "You have to be a patron to get a custom colour. If you are a patron and see this message, please contact a moderator.\n\nhttps://www.patreon.com/godotengine")
 
-    elif message.content.startswith("!sort_roles"):
-        for r in message.server.roles: #move donor role to position 1
-            if r.name.lower() == "donor":
-                await client.move_role(message.server, r, 1)
-                break
-        for r in message.server.roles: #move donor colour roles to position 2, so that the important roles stay above
-            if r.name.startswith("donor_"):
-                await client.move_role(message.server, r, 2)
-
-    elif message.content.startswith("!purge"): #delete colour roles for members who are no longer patrons
-        for admin in message.author.roles:
+    elif message.content.startswith("!sort"): # moving all the colour roles below Donor role
+        is_admin = False
+        for admin in message.author.roles: #check if admin
             if admin.name.lower() == "admin":
-                kills = 0
-                for m in message.server.members: #check if a user has donor color role but not a donor role
-                    if not "donor" in (r.name.lower() for r in m.roles):
-                        for role in m.roles:
-                            if role.name.startswith("donor_"):
-                                kills += 1
-                                await client.delete_role(message.server, role)
-                await client.send_message(message.channel, "kill count:  " + str(kills))
+                is_admin = True
                 break
+        if is_admin:
+            donor_pos = 0
+            server_role_list = message.server.roles.copy()
+            for r in server_role_list:
+                if r.name.lower() == "donor":
+                    donor_pos = r.position
+                    break
+            for r in server_role_list:
+                if r.name.lower().startswith("color"):
+                    await client.move_role(message.server, r, donor_pos - 1)
+
+    elif message.content.startswith("!purge"): # delete colour roles for members who are no longer patrons
+        is_admin = False
+        for admin in message.author.roles: #check if admin
+            if admin.name.lower() == "admin":
+                is_admin = True
+                break
+        if is_admin:
+            kills = 0
+            for m in message.server.members: #check if a user has donor color role but not a donor role
+                if not "donor" in (r.name.lower() for r in m.roles):
+                    for role in m.roles:
+                        if role.name.startswith("color"):
+                            kills += 1
+                            await client.delete_role(message.server, role)
+            await client.send_message(message.channel, "kill count:  " + str(kills))
+
 @client.event
 async def on_member_join(member):
     # Actions to take when a new member joins the server.

--- a/main.py
+++ b/main.py
@@ -560,6 +560,11 @@ async def on_message(message):
                     await delete_edit_timer(tmp, FEEDBACK_DEL_TIMER, call_msg=message)
                     return
                 role_name = "color_" + str(message.author)
+                author_roles = message.author.roles.copy()
+                for r in author_roles: #check if user has already a colour role and edit the colour
+                    if r.name.startswith("color"):
+                        await client.edit_role(message.server, r, colour=discord.Colour(role_colour))
+                        return
                 server_roles = message.server.roles.copy()
                 for r in server_roles: #check position of donor role
                     if r.name.lower() == "donor":
@@ -568,14 +573,10 @@ async def on_message(message):
                     message.server, name=role_name, colour=discord.Colour(role_colour)
                 )
                 await client.move_role(message.server, new_role, donor_pos)
-                author_roles = message.author.roles.copy()
-                for k in author_roles: #check if user has already a donor colour role and delete it
-                    if k.name.startswith("color"):
-                        await client.delete_role(message.server, k)
                 await client.add_roles(message.author, new_role)
         else:
             tmp = await client.send_message(
-                message.channel, "You have to be a patron to get a custom colour. If you are a patron and see this message, please contact a moderator.\n\nhttps://www.patreon.com/godotengine")
+                message.channel, "You have to be a patron to get a custom colour. If you are a patron and get this message, please contact a moderator.\n\nhttps://www.patreon.com/godotengine")
 
     elif message.content.startswith("!sort"): # moving all the colour roles below Donor role
         is_admin = False


### PR DESCRIPTION
Anyone who has the donor role can use this command to assign a new role with a custom colour to themselves. Let's say !patreon #ffffff creates a new role with white colour and it adds it to themselves. If there is already a role with the same name it deletes it. The name of the role is donor_c_[username],  but I don't know if it is something that is wanted, because there will be lots of roles, or if you would like to have a range of custom colours. Anyway your choice, I don't know if there is a better way. 