### PR TITLE
Correct 'Kid's can code' link

### DIFF
--- a/main.py
+++ b/main.py
@@ -573,7 +573,7 @@ async def on_message(message: Any) -> None:
     elif message.content.lower().startswith("!kcc"):
         # Kids Can Code YouTube channel.
         await message.channel.send(
-            "https://www.youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg"
+            "https://youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg/playlists"
         )
 
     elif message.content.lower().startswith("!mirror"):


### PR DESCRIPTION
Kids can code also does post Python tutorials, and the current link directs to his Youtube homepage, which shows exactly that and almost no sign of Godot.

The new link directs to his playlists, which shows tons of Godot playlists.

Current: 
![Screenshot_2020-09-13-10-02-21-87_7a4090f09f6554852d748ee9fd6f40d3](https://user-images.githubusercontent.com/6344099/93013596-1e4f9980-f5aa-11ea-8042-cf3a68dc655e.jpg)
